### PR TITLE
Increase speculative checks to 3

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,7 @@ queue_rules:
       - check-success=test
 
   - name: default
-    speculative_checks: 1
+    speculative_checks: 3
     batch_size: 1
     conditions:
       - check-success=test


### PR DESCRIPTION
Increase to 3 so we can test out merge queues with no PRs. 